### PR TITLE
Prevent ExampleCard buttons from submitting forms

### DIFF
--- a/src/components/ExampleCard.tsx
+++ b/src/components/ExampleCard.tsx
@@ -34,7 +34,8 @@ const CardContent = styled.p`
   margin: 0 0 ${({ theme }) => theme.spacing[6]} 0;
 `;
 
-const PrimaryButton = styled.button`
+// Ensure the button does not accidentally submit forms by default
+const PrimaryButton = styled.button.attrs({ type: 'button' })`
   background-color: ${({ theme }) => theme.colors.primary[500]};
   color: ${({ theme }) => theme.colors.white};
   border: none;
@@ -62,7 +63,8 @@ const PrimaryButton = styled.button`
   }
 `;
 
-const SecondaryButton = styled.button`
+// Ensure the button does not accidentally submit forms by default
+const SecondaryButton = styled.button.attrs({ type: 'button' })`
   background-color: transparent;
   color: ${({ theme }) => theme.colors.secondary[700]};
   border: 1px solid ${({ theme }) => theme.colors.secondary[300]};


### PR DESCRIPTION
## Summary
- Avoid accidental form submissions by defaulting ExampleCard buttons to `type="button"`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f892258ac8328a8750c3ff6c9e102